### PR TITLE
Update yeoman-generator dependency to fix  "yellow.bold" error on theme creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.12.0",
+    "yeoman-generator": "~0.13.0",
     "lodash": "~1.3.1",
     "underscore.string": "~2.3.3"
   },


### PR DESCRIPTION
According to https://github.com/yeoman/generator-webapp/issues/137 the yeoman generator replaced color.js with chalk and generators that don't update their dependency will experience errors.

Seems to be the source of https://github.com/pixelmord/generator-drupaltheme/issues/2
